### PR TITLE
Allow slugs to be optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var slug = require('slug-component');
  * 
  *      - `.replace` characters to replace defaulted to `[^a-zA-Z]`
  *      - `.separator` separator to use, defaulted to `-`
+ *      - `required` whether a slug is required, defaults to `true`
  *
  * @param {String} prop
  * @param {Object} options

--- a/index.js
+++ b/index.js
@@ -27,8 +27,9 @@ module.exports = function(prop, opts){
     schema.add({ slug: String });
     schema.pre('save', function(next){
       var title = this[prop || 'title'];
-      if (!title) return next(new Error(prop + ' is required to create a slug'));
-      this.slug = slug(title, opts);
+      var require = (opts && !opts.required) ? false : true;
+      if (require && !title) return next(new Error(prop + ' is required to create a slug'));
+      if (title) this.slug = slug(title, opts);
       next();
     });
   });


### PR DESCRIPTION
I've added the ability to specify a `required` boolean in the options object, that when `false` will allow a model to be saved without a slug.
